### PR TITLE
added damage reduction methods, and init function

### DIFF
--- a/Armor/$README.md
+++ b/Armor/$README.md
@@ -29,7 +29,7 @@ Additionally there is a custom skill using the keyword<> "Shear", it multiplies 
 
 ### Possible Conflicts
 
-- overwrites `DamageCalculator.calculateDefense`
+- overwrites `DamageCalculator.calculateDamage`
 - overwrites `NormalAttackOrderBuilder._configureEvaluator`
     - need to experiment with aliasing this one
 - includes numerous stat display changes that may be incompatible with StatBar plugin
@@ -40,7 +40,7 @@ Additionally there is a custom skill using the keyword<> "Shear", it multiplies 
 
 - ~~enable armor growth~~
 - separate magic and physical armor values
-- `ALWAYSREDUCE` damage mode -- reduce armor whenever hit, not just damaged
+- ~~`ALWAYSREDUCE` damage mode -- reduce armor whenever hit, not just damaged~~
 - ~~optionally refresh armor at the end of maps / on entering base~~
     - ~~relatedly, store current value and base value in different places for purposes of refreshing at points~~
 - enable item + weapon bonuses like other stats
@@ -57,6 +57,17 @@ Additionally there is a custom skill using the keyword<> "Shear", it multiplies 
 - display as `currentValue / maximumValue` in unit window
 - include stat gauge
 - enable armor refresh on map transition
+
+#### v1.2
+- FRACTION reduction mode and function expansion
+
+#### v1.3
+- added "shear", mechanic for interplay between weapons / skills and armor reduction
+
+#### v1.4
+- added two additional damage reduction methods
+    - percent based, where damage is reduced by configured percent as long as any armor is intact
+    - fixed, where damage is reduced by a set amount as long as any armor is intact
 
 ### File Breakdown
 

--- a/Armor/armor-config.js
+++ b/Armor/armor-config.js
@@ -13,6 +13,12 @@ var DAMAGE_MODE = {
     FRACTION: 3
 }
 
+var REDUCTION_MODE = {
+    STAT: 1, // damage reduced proportional to remaining armor
+    PERCENT: 2, // damage reduced as percentage (set at ArmorConfig.reduceValue, e.g. 20 is 20% reduction)
+    FIXED: 3 // damage reduced by fixed amount regardless of remaining armor (set at ArmorConfig.reduceValue, e.g. 3 is a fixed 3 damage difference)
+}
+
 /**
  * HEAL_MODE
  * NEVER -- if armor is damaged, do not automatically replenish
@@ -31,5 +37,7 @@ var ArmorConfig = {
     fractionDamage: 4, //amount to divide armor damage by
     shearOnly: true, // set to true to only damage armor with weapons that have a shear or shearmul value
     damageMode: DAMAGE_MODE.FIXED,
-    healMode: HEAL_MODE.MAP_END
+    healMode: HEAL_MODE.MAP_END,
+    reductionMode: REDUCTION_MODE.STAT,
+    reduceValue: 4
 }

--- a/Armor/armor-control.js
+++ b/Armor/armor-control.js
@@ -2,8 +2,7 @@
  * Controller for key armor methods + reduce modes
  */
 
-
-
+// used when damageMode is FIXED 
 var armorFixedReduce = function(virtualUnit, virtualPassiveUnit, damageSustained) {
     unit = virtualUnit.unitSelf;
     var atkweapon = ItemControl.getEquippedWeapon(virtualPassiveUnit.unitSelf);
@@ -35,6 +34,7 @@ var armorFixedReduce = function(virtualUnit, virtualPassiveUnit, damageSustained
     }
 }
 
+// used when damageMode is OVERFLOW
 var overDamageReduce = function(virtualUnit, virtualPassiveUnit, damageSustained) {
     unit = virtualUnit.unitSelf;
     var atkweapon = ItemControl.getEquippedWeapon(virtualPassiveUnit.unitSelf);
@@ -66,6 +66,7 @@ var overDamageReduce = function(virtualUnit, virtualPassiveUnit, damageSustained
     }
 }
 
+// used when damageMode is FRACTION
 var fractionDamageReduce = function(virtualUnit, virtualPassiveUnit, damageSustained) {
     unit = virtualUnit.unitSelf;
     var attacker = virtualPassiveUnit.unitSelf;
@@ -106,8 +107,39 @@ var handleReduction = function(unitArmor){ //just to clean it up a bit
     unit.custom.arm.value = unitArmor;
 }
 
+// used when reductionMode is STAT
+var statReduce = function(damage, armor) {
+    if (armor <= 0) {
+        return damage;
+    }
+    if (damage > armor) {
+        return damage - armor;
+    }
+    return 0;
+}
+
+// used when reductionMode is PERCENT
+var percentReduce = function(damage, armor) { 
+    if (armor != 0) {
+        return Math.floor(damage * (100 - ArmorConfig.reduceValue) / 100);
+    }
+    return damage;
+}
+
+// used when reductionMode is FIXED
+var fixedReduce = function(damage, armor) {
+    if (armor != 0) {
+        if (damage > ArmorConfig.reduceValue) {
+            return damage - ArmorConfig.reduceValue;
+        }
+        return 0;
+    }
+    return damage;
+}
+
 var ArmorControl = {
     reduceArmor: null,
+    adjustDamage: null,
     getArm: function(unit) {
         if (unit.custom.arm != null) {
             return unit.custom.arm.value;
@@ -144,10 +176,24 @@ var ArmorControl = {
 
 // this pattern eliminates mode calls at runtime, but may not be useful
 // if garbage collection doesn't remove unused functions
-if (ArmorConfig.damageMode == DAMAGE_MODE.FIXED) {
-    ArmorControl.reduceArmor = armorFixedReduce
-} else if (ArmorConfig.damageMode == DAMAGE_MODE.OVERFLOW) {
-    ArmorControl.reduceArmor = overDamageReduce
-} else if (ArmorConfig.damageMode == DAMAGE_MODE.FRACTION) {
-    ArmorControl.reduceArmor = fractionDamageReduce
+
+function init() {
+    // how is armor reduced?
+    if (ArmorConfig.damageMode == DAMAGE_MODE.FIXED) {
+        ArmorControl.reduceArmor = armorFixedReduce
+    } else if (ArmorConfig.damageMode == DAMAGE_MODE.OVERFLOW) {
+        ArmorControl.reduceArmor = overDamageReduce
+    } else if (ArmorConfig.damageMode == DAMAGE_MODE.FRACTION) {
+        ArmorControl.reduceArmor = fractionDamageReduce
+    }
+    // how does armor reduce character damage
+    if (ArmorConfig.reductionMode == REDUCTION_MODE.STAT) {
+        ArmorControl.adjustDamage = statReduce
+    } else if (ArmorConfig.reductionMode == REDUCTION_MODE.PERCENT) {
+        ArmorControl.adjustDamage = percentReduce
+    } else if (ArmorConfig.reductionMode == REDUCTION_MODE.FIXED) {
+        ArmorControl.adjustDamage = fixedReduce
+    }
 }
+
+init();

--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@
 
 - UnitRating -- enhanced version of another plugin enabling generation of a "unit rating" (per FE Awakening) 
     with stats that contribute unequally to the total by editing a config file
+- Armor -- add an "armor" stat which implements a depletable defense stat with various methods for damage reduction and armor depletion


### PR DESCRIPTION
resolves #8, resolves #9
### Adds

- mode for percent-based damage reduction when armor is intact (percent set in config) per #8 
- mode for fixed damage reduction when armor is intact (amount set in config) per #8
- `init()` method that wraps ArmorControl initialization per #9 

### Tweaks

- moves armor-based adjustments to damage from `DamageCalculator.calculateDefense` to `DamageCalculator.calculateDamage`